### PR TITLE
Fix udemy link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Protonmail
     Odysee
   </a>,
 
-  <a href="https:/www.udemy.com" target="">
+  <a href="https://www.udemy.com" target="">
     Udemy
   </a>`,
 ];

--- a/src/data/card1.js
+++ b/src/data/card1.js
@@ -18,7 +18,7 @@ export const cards = [
     Odysee
   </a>,
 
-  <a href="https:/www.udemy.com" target="">
+  <a href="https://www.udemy.com" target="">
     Udemy
   </a>,
 ];


### PR DESCRIPTION
Fixed udemy link typo,
When you click the link, it was redirects the user to /www.udemy.com which is https://yusufipk.github.io/www.udemy.com.
Now it's redirecting www.udemy.com which I think you want to redirect.